### PR TITLE
Link to meteorhacks:cluster at top of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # This is a archived project
 
+## Are you looking for the newer project [meteorhacks:cluster](https://github.com/meteorhacks/cluster) ?
+
 Meteor Cluster is now retired & Meteor's Collection implementation implementation with [Oplog](https://github.com/meteor/meteor/wiki/Oplog-Observe-Driver) support can be used to run a cluster of Meteor nodes.
 
 meteor-cluster [![Build Status](https://travis-ci.org/arunoda/meteor-cluster.png?branch=master)](https://travis-ci.org/arunoda/meteor-cluster)


### PR DESCRIPTION
This is the first hit Google is returning from a search of 'meteor cluster', and it's the second time I've been shocked to see the project has been discontinued only to then realise it's a different project! A nice big notice at the top should help
